### PR TITLE
Fix POD - add description to NAME

### DIFF
--- a/lib/Scalar/Type.pm
+++ b/lib/Scalar/Type.pm
@@ -32,11 +32,7 @@ use base qw(Exporter);
 
 =head1 NAME
 
-Scalar::Type
-
-=head1 DESCRIPTION
-
-Figure out what type a scalar is
+Scalar::Type - figure out what type a scalar is
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Scalar-Type.
We thought you might be interested in it too.

    Description: Fix POD - add description to NAME
     in order to get whatis entry in manpage
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2023-10-28
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libscalar-type-perl/raw/master/debian/patches/whatis.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
